### PR TITLE
Typo in ce5a26d: float/double words were serialized, but still restored.

### DIFF
--- a/src/Data/Bytes/Serial.hs
+++ b/src/Data/Bytes/Serial.hs
@@ -125,11 +125,11 @@ foreign import ccall word64ToDouble :: Word64 -> Double
 
 instance Serial Double where
   serialize = serialize . doubleToWord64
-  deserialize = liftM word64ToDouble restore
+  deserialize = liftM word64ToDouble deserialize
 
 instance Serial Float where
   serialize = serialize . floatToWord32
-  deserialize = liftM word32ToFloat restore
+  deserialize = liftM word32ToFloat deserialize
 
 instance Serial Char where
   serialize = putWord32be . fromIntegral . fromEnum


### PR DESCRIPTION
That did native-endian deserializing on floats, which is why 0.10.2 still didn't roundtrip.
