### PR TITLE
Lower version bounds on binary

### DIFF
--- a/bytes.cabal
+++ b/bytes.cabal
@@ -42,7 +42,7 @@ flag lib-Werror
 library
   build-depends:
     base                      >= 4.3      && < 5,
-    binary                    >= 0.7      && < 0.8,
+    binary                    >= 0.5.1    && < 0.8,
     bytestring                >= 0.9      && < 0.11,
     cereal                    >= 0.3.5    && < 0.4,
     containers                >= 0.3      && < 1,


### PR DESCRIPTION
This is just a cabal file change. With this change, the code compiles against binary 0.5.1.0 using GHC 7.4. However, I was unable to get the test suite to pass either with or without this change (using both GHC 7.4 and GHC 7.6) due to the following error:

```
Test suite doctests: RUNNING...
### Failure in src/Data/Bytes/VarInt.hs:35: expression `runPutL $ serialize (97 :: Word64)'
expected: "a\NUL\NUL\NUL\NUL\NUL\NUL\NUL"
 but got: 
          <interactive>:16:1: Not in scope: `runPutL'

          <interactive>:16:11: Not in scope: `serialize'

          <interactive>:16:28:
              Not in scope: type constructor or class `Word64'
```
