### PR TITLE
Do not rely on an installed bytes package for running tests

### DIFF
--- a/tests/doctests.hsc
+++ b/tests/doctests.hsc
@@ -59,7 +59,8 @@ main = withUnicode $ getSources >>= \sources -> doctest $
   : "-optPdist/build/autogen/cabal_macros.h"
   : "-hide-all-packages"
   : "-Iincludes"
-  : map ("-package="++) deps ++ sources
+  : "dist/build/cbits/i2d.o"
+  : map ("-package="++) (filter (not . ("bytes-" `isPrefixOf`)) deps) ++ sources
 
 getSources :: IO [FilePath]
 getSources = filter (isSuffixOf ".hs") <$> go "src"


### PR DESCRIPTION
Currently, `cabal install bytes --enable-tests` fails unless you've previously installed the same version of `bytes`. This patch fixes that by:
1. Removing the `-package=` option including `bytes` for doctest.
2. Manually include the generated object file.
