### PR TITLE
Fix test failure with bytestring 0.9

### DIFF
--- a/src/Data/Bytes/VarInt.hs
+++ b/src/Data/Bytes/VarInt.hs
@@ -36,9 +36,11 @@ import Data.Word
 
 -- | Integer/Word types serialized to base-128 variable-width ints.
 --
--- >>> runPutL $ serialize (97 :: Word64)
+-- >>> import Data.Monoid (mconcat)
+-- >>> import Data.ByteString.Lazy (toChunks)
+-- >>> mconcat $ toChunks $ runPutL $ serialize (97 :: Word64)
 -- "\NUL\NUL\NUL\NUL\NUL\NUL\NULa"
--- >>> runPutL $ serialize (97 :: VarInt Word64)
+-- >>> mconcat $ toChunks $ runPutL $ serialize (97 :: VarInt Word64)
 -- "a"
 newtype VarInt n = VarInt { unVarInt :: n }
   deriving (Eq, Ord, Show, Enum, Num, Integral, Bounded, Real, Bits)


### PR DESCRIPTION
The Show instance for lazy ByteStrings in 0.9 includes Chunk and Empty
garbage, which caused the tests to fail. This hacky solution is to
convert the lazy ByteString into a strict ByteString. There might be
better solutions, but I couldn't think of any.

Note that conditional compilation doesn't seem to play well with
doctests.
