### PR TITLE
Conservative

### DIFF
--- a/src/Data/Bytes/Serial.hs
+++ b/src/Data/Bytes/Serial.hs
@@ -20,10 +20,9 @@
 --
 -- This module contains four classes, each providing methods to
 -- serialize and deserialize types. 'Serial' is the main class, to
--- be used if there is a single, canonical way to serialize a
--- specific type. 'SerialBE' and 'SerialLE' in turn are used to
--- respectively implement big endian and little endian
--- serializations.
+-- be used for the canonical way to serialize a specific
+-- type. 'SerialBE' and 'SerialLE' in turn are used to respectively
+-- implement big endian and little endian serializations.
 --------------------------------------------------------------------
 module Data.Bytes.Serial
   ( SerialBE(..)


### PR DESCRIPTION
This should contain exactly the stuff we talked about on IRC
- Addition of `SerialBE`, `SerialLE`, and `SerialHost` classes
  - no endian-specific `Word` or `Int` instances because those types vary from machine to machine
- Fixing of `Data.Bytes.Serial` Module intro documentation
