### PR TITLE
It's impossible to define Serial1 instace for recursive data typesusing generics

### DIFF
--- a/src/Data/Bytes/Serial.hs
+++ b/src/Data/Bytes/Serial.hs
@@ -721,9 +721,9 @@ instance GSerial1 Par1 where
   gserializeWith f (Par1 a) = f a
   gdeserializeWith m = liftM Par1 m
 
-instance GSerial1 f => GSerial1 (Rec1 f) where
-  gserializeWith f (Rec1 fa) = gserializeWith f fa
-  gdeserializeWith m = liftM Rec1 (gdeserializeWith m)
+instance Serial1 f => GSerial1 (Rec1 f) where
+  gserializeWith f (Rec1 fa) = serializeWith f fa
+  gdeserializeWith m = liftM Rec1 (deserializeWith m)
 
 -- instance (Serial1 f, GSerial1 g) => GSerial1 (f :.: g) where
 


### PR DESCRIPTION
Current implementation cannot derive Serial1 instance for recursive data types. For example:

```{.haskell}
{-# LANGUAGE DeriveGeneric #-}
module Test where

import Data.Bytes.Serial
import GHC.Generics

data Tree a
  = Leaf a
  | Node (Tree a) (Tree a)
  deriving (Show,Eq,Generic,Generic1)

instance Serial1 Tree
```
fails to compile with following error message

```
bytes.hs:12:10:
    Could not deduce (GSerial1 Tree)
      arising from a use of ‘Data.Bytes.Serial.$gdmserializeWith’
    from the context (Data.Bytes.Put.MonadPut m)
      bound by the type signature for
                 serializeWith :: Data.Bytes.Put.MonadPut m =>
                                  (a -> m ()) -> Tree a -> m ()
      at bytes.hs:12:10-21
    In the expression: Data.Bytes.Serial.$gdmserializeWith
    In an equation for ‘serializeWith’:
        serializeWith = Data.Bytes.Serial.$gdmserializeWith
    In the instance declaration for ‘Serial1 Tree’
...
```

Note that for nonrecursive data types deriving works just fine. It appears that problem lies with instance for `Rec1`.  It requires constraint `GSerial1 f`but `f` is original data type and not its generic representation.

I'm not entirely sure this is correct. I've never used Generic1 type class before. I tested generic instance for Tree data type above and it does work correctly.