### PR TITLE
added unordered-containers support

### DIFF
--- a/bytes.cabal
+++ b/bytes.cabal
@@ -44,11 +44,13 @@ library
     bytestring                >= 0.9      && < 0.11,
     cereal                    >= 0.3.5    && < 0.5,
     containers                >= 0.3      && < 1,
+    hashable                  >= 1.0.1.1  && < 1.4,
     mtl                       >= 2.0      && < 2.3,
     text                      >= 0.2      && < 1.3,
     time                      >= 1.2      && < 1.6,
     transformers              >= 0.2      && < 0.5,
     transformers-compat       >= 0.3      && < 1,
+    unordered-containers      >= 0.2      && < 0.3,
     void                      >= 0.6      && < 1
 
   if impl(ghc >= 7.4 && < 7.6)


### PR DESCRIPTION
I don't love this implementation, but I don't know how else to handle unordered-containers stuff in the presence of platform-dependent hashing.