### PR TITLE
Bump lower bound on base to exclude GHC < 7.4

### DIFF
--- a/bytes.cabal
+++ b/bytes.cabal
@@ -39,7 +39,7 @@ flag test-doctests
 
 library
   build-depends:
-    base                      >= 4.3      && < 5,
+    base                      >= 4.5      && < 5,
     binary                    >= 0.5.1    && < 0.8,
     bytestring                >= 0.9      && < 0.11,
     cereal                    >= 0.3.5    && < 0.5,


### PR DESCRIPTION
addresses #22