### PR TITLE
Allow time-1.7

### DIFF
--- a/bytes.cabal
+++ b/bytes.cabal
@@ -55,7 +55,7 @@ library
     hashable                  >= 1.0.1.1  && < 1.4,
     mtl                       >= 2.0      && < 2.3,
     text                      >= 0.2      && < 1.3,
-    time                      >= 1.2      && < 1.7,
+    time                      >= 1.2      && < 1.8,
     transformers              >= 0.2      && < 0.6,
     transformers-compat       >= 0.3      && < 1,
     unordered-containers      >= 0.2      && < 0.3,


### PR DESCRIPTION
Not sure whether @hvr's `ghc-head` has `time-1.7` (--allow-newer hided that bound restriction previously)