### PR TITLE
Binary orphans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.3.20190425
+# version: 0.3.20190429
 #
 language: c
 dist: xenial
@@ -132,7 +132,7 @@ install:
     echo 'packages: "."' >> cabal.project
   - |
     echo "write-ghc-environment-files: always" >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(bytes)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(bytes)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   - if [ -f "./configure.ac" ]; then (cd "." && autoreconf -i); fi
@@ -155,7 +155,7 @@ script:
     echo 'packages: "bytes-*/*.cabal"' >> cabal.project
   - |
     echo "write-ghc-environment-files: always" >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(bytes)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(bytes)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   # Building with tests and benchmarks...

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+0.16 [xxxx.xx.xx]
+-----------------
+
+* Support GHC-8.8
+* `MonadGet now requires `MonadFail` as a superclass
+
 0.15.5 [2018.07.03]
 -------------------
 * Add `Serial(1)` instances for `NonEmpty`.

--- a/bytes.cabal
+++ b/bytes.cabal
@@ -1,6 +1,6 @@
 name:          bytes
 category:      Data, Serialization
-version:       0.15.5
+version:       0.16
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE
@@ -47,7 +47,7 @@ flag test-doctests
   manual: True
 
 custom-setup
-  -- any should do
+  -- any Cabal should do
   setup-depends:
     base          >= 4.5 && <5,
     Cabal         >= 1.14,
@@ -58,15 +58,16 @@ library
   build-depends:
     base                      >= 4.5      && < 5,
     binary                    >= 0.5.1    && < 0.9,
+    binary-orphans            >= 1.0.1    && < 1.1,
     bytestring                >= 0.9      && < 0.11,
-    cereal                    >= 0.3.5    && < 0.6,
+    cereal                    >= 0.5.2    && < 0.6,
     containers                >= 0.3      && < 1,
     hashable                  >= 1.0.1.1  && < 1.4,
     mtl                       >= 2.0      && < 2.3,
     text                      >= 0.2      && < 1.3,
     time                      >= 1.2      && < 1.10,
     transformers              >= 0.2      && < 0.6,
-    transformers-compat       >= 0.3      && < 1,
+    transformers-compat       >= 0.6.5    && < 1,
     unordered-containers      >= 0.2      && < 0.3,
     scientific                >= 0.0      && < 1,
     void                      >= 0.6      && < 1
@@ -74,8 +75,9 @@ library
   if impl(ghc >= 7.4 && < 7.6)
     build-depends: ghc-prim
 
-  if impl(ghc < 8.0)
+  if !impl(ghc >= 8.0)
     build-depends: semigroups >= 0.5      && < 1
+                 , fail       >= 4.9.0.0  && < 4.10
 
   exposed-modules:
     Data.Bytes.Get

--- a/src/Data/Bytes/Get.hs
+++ b/src/Data/Bytes/Get.hs
@@ -43,7 +43,11 @@ import Data.Int
 import qualified Data.Serialize.Get as S
 import Data.Word
 
-class (Integral (Remaining m), Monad m, Applicative m) => MonadGet m where
+import Control.Monad.Trans.Instances ()
+import Data.Binary.Orphans ()
+import qualified Control.Monad.Fail as Fail
+
+class (Integral (Remaining m), Fail.MonadFail m, Applicative m) => MonadGet m where
   -- | An 'Integral' number type used for unchecked skips and counting.
   type Remaining m :: *
 
@@ -211,7 +215,7 @@ instance MonadGet B.Get where
   {-# INLINE lookAheadE #-}
   ensure n = do
     bs <- lookAhead $ getByteString n
-    unless (Strict.length bs >= n) $ fail "ensure: Required more bytes"
+    unless (Strict.length bs >= n) $ Fail.fail "ensure: Required more bytes"
     return bs
   {-# INLINE ensure #-}
   getBytes = B.getByteString


### PR DESCRIPTION
I wonder if `Semigroups` instances should be put into `semigroups`? Yet, this way it's simpler.

I'm going to repurpose `binary-orphans` to these needs, and make `binary-instances`; that way we'll get a bit more consistent package naming