### PR TITLE
Properly support bytestring-0.11

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -5,7 +5,8 @@ next [yyyy.mm.dd]
   [`cabal-docspec`](https://github.com/phadej/cabal-extras/tree/master/cabal-docspec)
   to run the doctests.
 * Provide `Serial Natural` instance unconditionally
-  
+* Allow building with `bytestring-0.11.*`.
+
 0.17 [2020.02.03]
 -----------------
 * Give `MonadGet m` a superclass of

--- a/src/Data/Bytes/Serial.hs
+++ b/src/Data/Bytes/Serial.hs
@@ -288,7 +288,13 @@ store a = putByteString bs
 restore :: forall m a. (MonadGet m, Storable a) => m a
 restore = do
   let required = sizeOf (undefined :: a)
-  PS fp o n <- getByteString required
+#if MIN_VERSION_bytestring(0,11,0)
+  let o = 0
+  BS fp n
+#else
+  PS fp o n
+#endif
+    <- getByteString required
   unless (n >= required) $ MonadFail.fail "restore: Required more bytes"
   return $ unsafePerformIO $ withForeignPtr fp $ \p -> peekByteOff p o
 


### PR DESCRIPTION
It was pointed out in ekmett/bytes#52 that my patch to allow `bytes` to build with `bytestring-0.11.*` in ed6135e1b59da7b46407d3fdc9b161810bac8baa was incomplete. This is because I overlooked the fact that `bytestring-0.11.*` only exports the `PS` pattern synonym on GHC 8.0 or later, and since `bytes` matches on `PS`, it wouldn't compile if you combined `bytestring-0.11` with a pre-8.0 version of GHC.

I adopted a similar fix as in https://github.com/ekmett/lens/commit/1debced4e9cb8b904b1f52c3ab10a551e40f3b2d#diff-700f6fcfab7d955dd35e76a01956c66b89cff9f681274163b6d60051229ef14dR217 to allow `bytestring-0.11` to be used with all supported versions of GHC.

Fixes #52.